### PR TITLE
fix: Remove unused imports

### DIFF
--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -10,7 +10,6 @@ from hist import Hist
 import json
 from optparse import OptionParser
 try:
-    import HiggsAnalysis.CombinedLimit.DatacardParser as DP
     from HiggsAnalysis.CombinedLimit.Datacard import Datacard
 except:
     print("Either the docker container has not been created properly or Combine commands have not been mounted. Please fix this and try again")

--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -10,7 +10,7 @@ from hist import Hist
 import json
 from optparse import OptionParser
 try:
-    from HiggsAnalysis.CombinedLimit.DatacardParser import *
+    import HiggsAnalysis.CombinedLimit.DatacardParser as DP
     from HiggsAnalysis.CombinedLimit.Datacard import Datacard
 except:
     print("Either the docker container has not been created properly or Combine commands have not been mounted. Please fix this and try again")


### PR DESCRIPTION
Resolves #7 

This was migrated from PR #8 for clarity after some rebasing.

`HiggsAnalysis.CombinedLimit.DatacardParser` is never used in `pyhf_convert_to_datacard.py` so remove it to avoid importing things into the local scope unnecessarily.

```
* `HiggsAnalysis.CombinedLimit.DatacardParser` is never used in
pyhf_convert_to_datacard.py so remove it to avoid importing things
into the local scope unnecessarily.

Co-authored-by: Peter Ridolfi <petey.ridolfi7@gmail.com>
```