### PR TITLE
feat: Use VCS for dynamic versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,129 @@
-*.tar.gz
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
 dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# dynamic vcs versioning
+*/pyhf_combine_converter/version.py
+
+# General
+.DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyhf_combine_converter"
-version = "0.0.4"
 authors = [
   { name="Peter Ridolfi", email="petey.ridolfi7@gmail.com" },
 ]
@@ -22,7 +21,12 @@ dependencies = [
   "uproot>=4.2.3",
   "hist>=2.6.1"
 ]
+dynamic = ["version"]
 
 [project.urls]
 "Homepage" = "https://github.com/peterridolfi/Pyhf-to-Combine-converter"
 "Bug Tracker" = "https://github.com/peterridolfi/Pyhf-to-Combine-converter/issues"
+
+[tool.hatch]
+version.source = "vcs"
+build.hooks.vcs.version-file = "src/pyhf_combine_converter/version.py"


### PR DESCRIPTION
Resolves #15

To avoid having to figure out when to bump versions, use the version control system to dynamically determine the version from the commit numbers since the last git tag (which should correspond to a release). This is done with `hatch`'s vcs tool and it will generate a file at `src/pyhf_combine_converter/version.py` that contains the version information for tools to use, but is ignored from the version control to avoid problems as this file is dynamically updated.

```
* Use hatch's vcs tooling to dynamically version the package.
* Use GitHub's .gitignore template for greater coverage.
* Ignore src/pyhf_combine_converter/version.py from version control.
```