### PR TITLE
feat: Add __version__ attribute to get easy version information

### DIFF
--- a/src/pyhf_combine_converter/__init__.py
+++ b/src/pyhf_combine_converter/__init__.py
@@ -1,0 +1,2 @@
+# Convenient access to the version number
+from pyhf_combine_converter.version import version as __version__


### PR DESCRIPTION
This allow for a user to know what version they have at runtime by doing the following

```python
>>> import pyhf_combine_converter
>>> pyhf_combine_converter.__version__  # version info at this commit
'0.0.3.dev7+g7748055'
```

This PR is a follow up to elements of PR #16.