### PR TITLE
feat: Add CLI API to package

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,28 @@ source /cvmfs/cms.cern.ch/cmsset_default.sh
 cmsenv
 ```
 
-After the container has been built, use the following commands to run the tool
+## Install
 
-For pyhf->combine:
-
-```
-python3 pyhf_convert_to_datacard.py $JSON_FILE_NAME --shape-file $SHAPES_FILE_NAME --out-datacard $DATACARD_FILE_NAME
-```
-
-For combine->pyhf:
+`pyhf_combine_converter` can be installed from PyPI. Inside of the Python environment containing Combine run
 
 ```
-python3 pyhf_converted_from_datacard.py $DATACARD_FILE_NAME --out-file $JSON_FILE_NAME
+python3 -m pip install pyhf_combine_converter
+```
 
+## Use
+
+`pyhf_combine_converter` provides a CLI API for bidirectional conversion between pyhf and Combine.
+
+### Convert from pyhf to Combine
+
+```
+pyhf-to-combine $JSON_FILE_NAME --shape-file $SHAPES_FILE_NAME --out-datacard $DATACARD_FILE_NAME
+```
+
+### Convert from Combine to pyhf
+
+```
+combine-to-pyhf $DATACARD_FILE_NAME --out-file $JSON_FILE_NAME
+```
 
 Any questions or issues should be referred to the docs/ folder, in which the translation is put into more detail.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
-# Pyhf-to-Combine-converter
+# pyhf-to-Combine-converter
+
 Tool to convert models from pyhf to CMS Combine and vise versa
 
 Zenodo DOI: [![DOI](https://zenodo.org/badge/492820903.svg)](https://zenodo.org/badge/latestdoi/492820903)
 
 This tool has been fully verified to produce the same model structure and expected yields, as well as to produce fits that are within 1% of the central value of each other. This has been done through the comparison of NLL plots, pull plots, and raw difference calculations.
 
-In order to use the package, one must first create a docker container that is capable of running Combine. To do so, enter the following commands once you have docker installed.
+## Environment for Combine
+
+In order to use the package, one must first create a docker container that is capable of running Combine. To do so, enter the following commands once you have Docker installed.
 
 ```
 docker pull pyhf/pyhf-combine-converter:cmssw-11.2.0-python3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,10 @@ dynamic = ["version"]
 "Homepage" = "https://github.com/peterridolfi/Pyhf-to-Combine-converter"
 "Bug Tracker" = "https://github.com/peterridolfi/Pyhf-to-Combine-converter/issues"
 
+[project.scripts]
+pyhf-to-combine = "pyhf_combine_converter.pyhf_convert_to_datacard:main"
+combine-to-pyhf = "pyhf_combine_converter.pyhf_converted_from_datacard:main"
+
 [tool.hatch]
 version.source = "vcs"
 build.hooks.vcs.version-file = "src/pyhf_combine_converter/version.py"

--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -51,16 +51,20 @@ def addChannels(file, spec, data_card, channel_bins):
             file[channel["name"] + "/data_obs"] = h_data
 
 
-def addSamples():  ##add sample names and expected counts to the Datacard
+def addSamples(file, spec, data_card, channel_bins, samples, options):
+    """
+    Add sample names and expected counts to the Datacard
+    """
     data_card.processes = samples
 
     for idxc, channel in enumerate(spec["channels"]):
-        if data_card.hasShapes == False:  ##counting
-            for idxs, sample in enumerate(channel["samples"]):
+        if data_card.hasShapes == False:  # counting
+            for sample in channel["samples"]:
                 data_card.exp[channel["name"]].update(
                     {sample["name"]: sample["data"][0]}
                 )
-        else:  ##shapes
+        else:
+            # shapes
             data_card.shapeMap.update({channel["name"]: {}})
             data_card.shapeMap[channel["name"]].update(
                 {"data_obs": [options.shapefile, channel["name"] + "/" + "data_obs"]}
@@ -75,7 +79,8 @@ def addSamples():  ##add sample names and expected counts to the Datacard
                         spec["channels"][idxc]["samples"][idxs]["modifiers"]
                     )
                 ]
-                if "histosys" in mods:  ##if shape uncertainty histogram is available
+                if "histosys" in mods:
+                    # if shape uncertainty histogram is available
                     data_card.shapeMap[channel["name"]].update(
                         {
                             spec["channels"][idxc]["samples"][idxs]["name"]: [
@@ -101,9 +106,8 @@ def addSamples():  ##add sample names and expected counts to the Datacard
                             ]
                         }
                     )
-                if (
-                    "staterror" in mods
-                ):  ##if staterror is present, provide variances for histograms
+                if "staterror" in mods:
+                    # if staterror is present, provide variances for histograms
                     h_data = hist.Hist.new.Regular(
                         channel_bins[channel["name"]], 0, channel_bins[channel["name"]]
                     ).Weight()
@@ -121,7 +125,7 @@ def addSamples():  ##add sample names and expected counts to the Datacard
                         axis=-1,
                     )
                     data_card.binParFlags.update({channel["name"]: True})
-                elif "shapesys" in mods:  ##for shapesys, also provide variances
+                elif "shapesys" in mods:  # for shapesys, also provide variances
                     h_data = hist.Hist.new.Regular(
                         channel_bins[channel["name"]], 0, channel_bins[channel["name"]]
                     ).Weight()
@@ -138,14 +142,14 @@ def addSamples():  ##add sample names and expected counts to the Datacard
                         axis=-1,
                     )
                     data_card.binParFlags.update({channel["name"]: True})
-                else:  ##no staterror or shapesys->0 variance
+                else:  # no staterror or shapesys->0 variance
                     h_data = hist.Hist.new.Regular(
                         channel_bins[channel["name"]], 0, channel_bins[channel["name"]]
                     ).Weight()
                     h_data[...] = np.stack(
                         [
                             spec["channels"][idxc]["samples"][idxs]["data"],
-                            [0 for i in range(channel_bins[channel["name"]])],
+                            [0 for _ in range(channel_bins[channel["name"]])],
                         ],
                         axis=-1,
                     )
@@ -545,7 +549,7 @@ def main():
 
     file = uproot.recreate(options.shapefile)
     addChannels(file, spec, data_card, channel_bins)
-    addSamples()
+    addSamples(file, spec, data_card, channel_bins, samples, options)
     addMods()
     addSignal()
     addRateParams()

--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -9,10 +9,13 @@ import hist
 from hist import Hist
 import json
 from optparse import OptionParser
+
 try:
     from HiggsAnalysis.CombinedLimit.Datacard import Datacard
 except:
-    print("Either the docker container has not been created properly or Combine commands have not been mounted. Please fix this and try again")
+    print(
+        "Either the docker container has not been created properly or Combine commands have not been mounted. Please fix this and try again."
+    )
 
 
 def addChannels():  ##add each channel to Datacard object, add observed counts
@@ -486,19 +489,29 @@ def writeDataCard(path):  ##manually write each line of the datacard from DC obj
                         )
         f.close()
 
+
 def main():
     parser = OptionParser()  # add command line args
     parser.add_option(
-        "-O", "--out-datacard", dest="outdatacard", default="converted_datacard.txt", help = "desired name of datacard file"
+        "-O",
+        "--out-datacard",
+        dest="outdatacard",
+        default="converted_datacard.txt",
+        help="desired name of datacard file",
     )
-    parser.add_option("-s", "--shape-file", dest="shapefile", default="shapes.root", help = "desired name of shapes file")
+    parser.add_option(
+        "-s",
+        "--shape-file",
+        dest="shapefile",
+        default="shapes.root",
+        help="desired name of shapes file",
+    )
     options, args = parser.parse_args()
 
     with open(args[0]) as serialized:
         spec = json.load(serialized)
     workspace = pyhf.Workspace(spec)
     model = workspace.model()
-
 
     channels = model.config.channels
     channel_bins = model.config.channel_nbins
@@ -514,9 +527,7 @@ def main():
                 if "staterror" not in mod:
                     systs.append(mod)
 
-
     DC = Datacard()
-
 
     file = uproot.recreate(options.shapefile)
     addChannels()
@@ -526,6 +537,7 @@ def main():
     addRateParams()
     file.close()
     writeDataCard(options.outdatacard)
+
 
 if __name__ == "__main__":
     main()

--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -18,28 +18,32 @@ except:
     )
 
 
-def addChannels():  ##add each channel to Datacard object, add observed counts
-    data_card.bins = [channel["name"] for i, channel in enumerate(spec["channels"])]
-    for idxc, channel in enumerate(spec["channels"]):
+def addChannels(file, spec, data_card, channel_bins):
+    """
+    Add each channel to Datacard object, add observed counts
+    """
+    data_card.bins = [channel["name"] for channel in spec["channels"]]
+    for channel in spec["channels"]:
         if channel_bins[channel["name"]] != 1:
             data_card.hasShapes = True
     for idxc, channel in enumerate(spec["channels"]):
         data_card.exp.update({channel["name"]: {}})
-        if data_card.hasShapes == False:  ##single bin
+        # single bin
+        if data_card.hasShapes == False:
             data_card.obs.update(
                 {channel["name"]: spec["observations"][idxc]["data"][0]}
             )
-
         else:
             data = sum(spec["observations"][idxc]["data"])
             data_card.obs.update({channel["name"]: data})
             h_data = hist.Hist.new.Regular(
                 channel_bins[channel["name"]], 0, channel_bins[channel["name"]]
             ).Weight()
+
             h_data[...] = np.stack(
                 [
                     spec["observations"][idxc]["data"],
-                    [0 for i in range(channel_bins[channel["name"]])],
+                    [0 for _ in range(channel_bins[channel["name"]])],
                 ],
                 axis=-1,
             )
@@ -540,7 +544,7 @@ def main():
     data_card = Datacard()
 
     file = uproot.recreate(options.shapefile)
-    addChannels()
+    addChannels(file, spec, data_card, channel_bins)
     addSamples()
     addMods()
     addSignal()

--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -367,145 +367,106 @@ def addRateParams():  ##add normfactor mods as rateParams (excluding signal stre
                                     ].append([[mod["name"], 1, 0], ""])
 
 
-def writeDataCard(
-    path,
-):  ##manually write each line of the datacard from data_card object
+def write_data_card(spec, data_card, channels, path):
+    """
+    Manually write each line of the datacard from data_card object
+    """
     with open(path, "w") as f:
-        f.write("imax " + str(size(data_card.bins)) + "\n")
+        f.write(f"imax {str(size(data_card.bins))}" + "\n")
         f.write(
             "jmax "
             + str(size(data_card.processes) - size(data_card.isSignal.keys()))
             + "\n"
         )
-        f.write("kmax " + str(size(data_card.systs, 0)) + "\n")
+        f.write(f"kmax {str(size(data_card.systs, 0))}" + "\n")
+
         if data_card.hasShapes:
             for channel in data_card.shapeMap.keys():
                 for sample in data_card.shapeMap[channel].keys():
                     f.write(
-                        "shapes "
-                        + sample
-                        + "  "
-                        + channel
-                        + "  "
-                        + data_card.shapeMap[channel][sample][0]
-                        + "  "
-                        + data_card.shapeMap[channel][sample][1]
+                        f"shapes {sample}  {channel}  {data_card.shapeMap[channel][sample][0]}  {data_card.shapeMap[channel][sample][1]}"
                     )
                     if size(data_card.shapeMap[channel][sample]) > 2:
-                        f.write("  " + data_card.shapeMap[channel][sample][2] + "\n")
+                        f.write(f"  {data_card.shapeMap[channel][sample][2]}" + "\n")
                     else:
                         f.write("\n")
 
         f.write("\n---------------------------------\n")
         f.write("bin ")
         for bin in data_card.obs.keys():
-            f.write(bin + " ")
+            f.write(f"{bin} ")
         f.write("\n")
         f.write("observation ")
         for channel in data_card.obs.keys():
-            f.write(str(data_card.obs[channel]) + " ")
+            f.write(f"{str(data_card.obs[channel])} ")
         f.write("\n---------------------------------\n")
         f.write("bin     ")
         for channel in data_card.obs.keys():
             for sample in data_card.exp[channel].keys():
-                f.write(channel + "    ")
+                f.write(f"{channel}    ")
         f.write("\n")
         f.write("process     ")
         for channel in data_card.bins:
             for sample in data_card.exp[channel].keys():
-                f.write(sample + "    ")
+                f.write(f"{sample}    ")
         f.write("\n")
         f.write("process     ")
         for channel in data_card.bins:
             for sample in data_card.exp[channel].keys():
                 if sample in data_card.signals:
-                    f.write(str(-1 * data_card.processes.index(sample)) + "     ")
+                    f.write(f"{str(-1 * data_card.processes.index(sample))}     ")
                 else:
-                    f.write(str(data_card.processes.index(sample) + 1) + "     ")
+                    f.write(f"{str(data_card.processes.index(sample) + 1)}     ")
         f.write("\n")
         f.write("rate     ")
         for channel in data_card.bins:
             for sample in data_card.exp[channel].keys():
 
-                f.write(str(data_card.exp[channel][sample]) + "     ")
+                f.write(f"{str(data_card.exp[channel][sample])}     ")
         f.write("\n---------------------------------\n")
         for syst in data_card.systs:
-            f.write(syst[0] + "  " + syst[2] + "  ")
+            f.write(f"{syst[0]}  {syst[2]}  ")
             for bin in syst[4].keys():
                 for sample in data_card.exp[bin].keys():
                     if syst[4][bin][sample] != 0:
-                        f.write(str(syst[4][bin][sample]) + "  ")
+                        f.write(f"{str(syst[4][bin][sample])}  ")
                     else:
                         f.write("-       ")
 
             f.write("\n")
         f.write("\n---------------------------------\n")
         for cAp in data_card.rateParams.keys():
-            dir = cAp.split("AND")
+            _dir = cAp.split("AND")
             for i in range(size(data_card.rateParams[cAp], 0)):
                 if size(data_card.rateParams[cAp][i][0]) > 3:
                     f.write(
-                        str(data_card.rateParams[cAp][i][0][0])
-                        + " "
-                        + "rateParam "
-                        + dir[0]
-                        + " "
-                        + dir[1]
-                        + " "
-                        + str(data_card.rateParams[cAp][i][0][1])
-                        + " "
-                        + data_card.rateParams[cAp][i][0][3]
+                        f"{str(data_card.rateParams[cAp][i][0][0])} rateParam {_dir[0]} {_dir[1]} {str(data_card.rateParams[cAp][i][0][1])} {data_card.rateParams[cAp][i][0][3]}"
                     )
                 else:
                     f.write(
-                        str(data_card.rateParams[cAp][i][0][0])
-                        + " "
-                        + "rateParam "
-                        + dir[0]
-                        + " "
-                        + dir[1]
-                        + " "
-                        + str(data_card.rateParams[cAp][i][0][1])
+                        f"{str(data_card.rateParams[cAp][i][0][0])} rateParam {_dir[0]} {_dir[1]} {str(data_card.rateParams[cAp][i][0][1])}"
                     )
                 f.write("\n")
         f.write("\n---------------------------------\n")
         for idxc, channel in enumerate(channels):
-            if channel in data_card.binParFlags.keys():
-                if data_card.binParFlags[channel] == True:  ##double check to be safe
-                    shapesys = False
-                    staterror = False
-                    for idxs, sample in enumerate(spec["channels"][idxc]["samples"]):
-                        if "shapesys" in [
-                            mod["type"] for i, mod in enumerate(sample["modifiers"])
-                        ]:
-                            shapesys = True
-                        elif "staterror" in [
-                            mod["type"] for i, mod in enumerate(sample["modifiers"])
-                        ]:
-                            staterror = True
-                    if shapesys == True:
-                        f.write(
-                            channel
-                            + " autoMCStats "
-                            + str(100000)
-                            + " "
-                            + str(0)
-                            + " "
-                            + str(2)
-                            + "\n"
-                        )
-                    if staterror == True:
-                        f.write(
-                            channel
-                            + " autoMCStats "
-                            + str(0)
-                            + " "
-                            + str(0)
-                            + " "
-                            + str(2)
-                            + "\n"
-                        )
-        f.close()
+            if (
+                channel in data_card.binParFlags.keys()
+                and data_card.binParFlags[channel] == True
+            ):
+                # double check to be safe
+                shapesys = False
+                staterror = False
+                for sample in spec["channels"][idxc]["samples"]:
+                    mod_types = [mod["type"] for mod in sample["modifiers"]]
+                    if "shapesys" in mod_types:
+                        shapesys = True
+                    elif "staterror" in mod_types:
+                        staterror = True
+
+                if shapesys:
+                    f.write(f"{channel} autoMCStats 100000 0 2" + "\n")
+                if staterror:
+                    f.write(f"{channel} autoMCStats 0 0 2" + "\n")
 
 
 def main():
@@ -554,7 +515,7 @@ def main():
     addSignal()
     addRateParams()
     file.close()
-    writeDataCard(options.outdatacard)
+    write_data_card(spec, data_card, channels, options.outdatacard)
 
 
 if __name__ == "__main__":

--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -309,20 +309,19 @@ def addMods(file, spec, data_card, channel_bins, systs):
                                 ] = lo_data
 
 
-def addSignal():  ##determine which samples are signal
-    measurements = []
-    for im, measurement in enumerate(spec["measurements"]):
-        measurements.append(measurement["config"]["poi"])
-    signalMods = []
-    for modifier in modifiers:
-        if modifier[0] in measurements:
-            signalMods.append(modifier[0])
-    for idxc, channel in enumerate(channels):
+def addSignal(spec, data_card, channels, modifiers):
+    """
+    Determine which samples are signal
+    """
+    measurements = [
+        measurement["config"]["poi"] for measurement in spec["measurements"]
+    ]
+    signal_mods = [modifier[0] for modifier in modifiers if modifier[0] in measurements]
+
+    for idxc, _ in enumerate(channels):
         for idxs, sample in enumerate(spec["channels"][idxc]["samples"]):
-            for i, mod in enumerate(
-                spec["channels"][idxc]["samples"][idxs]["modifiers"]
-            ):
-                for sig in signalMods:
+            for mod in spec["channels"][idxc]["samples"][idxs]["modifiers"]:
+                for sig in signal_mods:
                     if sig == mod["name"]:
                         data_card.isSignal.update({sample["name"]: True})
                         data_card.signals.append(sample["name"])
@@ -516,7 +515,7 @@ def main():
     addChannels(file, spec, data_card, channel_bins)
     addSamples(file, spec, data_card, channel_bins, samples, options)
     addMods(file, spec, data_card, channel_bins, systs)
-    addSignal()
+    addSignal(spec, data_card, channels, modifiers)
     addRateParams()
     file.close()
     write_data_card(spec, data_card, channels, options.outdatacard)

--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -19,18 +19,20 @@ except:
 
 
 def addChannels():  ##add each channel to Datacard object, add observed counts
-    DC.bins = [channel["name"] for i, channel in enumerate(spec["channels"])]
+    data_card.bins = [channel["name"] for i, channel in enumerate(spec["channels"])]
     for idxc, channel in enumerate(spec["channels"]):
         if channel_bins[channel["name"]] != 1:
-            DC.hasShapes = True
+            data_card.hasShapes = True
     for idxc, channel in enumerate(spec["channels"]):
-        DC.exp.update({channel["name"]: {}})
-        if DC.hasShapes == False:  ##single bin
-            DC.obs.update({channel["name"]: spec["observations"][idxc]["data"][0]})
+        data_card.exp.update({channel["name"]: {}})
+        if data_card.hasShapes == False:  ##single bin
+            data_card.obs.update(
+                {channel["name"]: spec["observations"][idxc]["data"][0]}
+            )
 
         else:
             data = sum(spec["observations"][idxc]["data"])
-            DC.obs.update({channel["name"]: data})
+            data_card.obs.update({channel["name"]: data})
             h_data = hist.Hist.new.Regular(
                 channel_bins[channel["name"]], 0, channel_bins[channel["name"]]
             ).Weight()
@@ -46,20 +48,22 @@ def addChannels():  ##add each channel to Datacard object, add observed counts
 
 
 def addSamples():  ##add sample names and expected counts to the Datacard
-    DC.processes = samples
+    data_card.processes = samples
 
     for idxc, channel in enumerate(spec["channels"]):
-        if DC.hasShapes == False:  ##counting
+        if data_card.hasShapes == False:  ##counting
             for idxs, sample in enumerate(channel["samples"]):
-                DC.exp[channel["name"]].update({sample["name"]: sample["data"][0]})
+                data_card.exp[channel["name"]].update(
+                    {sample["name"]: sample["data"][0]}
+                )
         else:  ##shapes
-            DC.shapeMap.update({channel["name"]: {}})
-            DC.shapeMap[channel["name"]].update(
+            data_card.shapeMap.update({channel["name"]: {}})
+            data_card.shapeMap[channel["name"]].update(
                 {"data_obs": [options.shapefile, channel["name"] + "/" + "data_obs"]}
             )
             for idxs, sample in enumerate(channel["samples"]):
                 data = sum(sample["data"])
-                DC.exp[channel["name"]].update({sample["name"]: data})
+                data_card.exp[channel["name"]].update({sample["name"]: data})
 
                 mods = [
                     spec["channels"][idxc]["samples"][idxs]["modifiers"][i]["type"]
@@ -68,7 +72,7 @@ def addSamples():  ##add sample names and expected counts to the Datacard
                     )
                 ]
                 if "histosys" in mods:  ##if shape uncertainty histogram is available
-                    DC.shapeMap[channel["name"]].update(
+                    data_card.shapeMap[channel["name"]].update(
                         {
                             spec["channels"][idxc]["samples"][idxs]["name"]: [
                                 options.shapefile,
@@ -83,7 +87,7 @@ def addSamples():  ##add sample names and expected counts to the Datacard
                         }
                     )
                 else:
-                    DC.shapeMap[channel["name"]].update(
+                    data_card.shapeMap[channel["name"]].update(
                         {
                             spec["channels"][idxc]["samples"][idxs]["name"]: [
                                 options.shapefile,
@@ -112,7 +116,7 @@ def addSamples():  ##add sample names and expected counts to the Datacard
                         ],
                         axis=-1,
                     )
-                    DC.binParFlags.update({channel["name"]: True})
+                    data_card.binParFlags.update({channel["name"]: True})
                 elif "shapesys" in mods:  ##for shapesys, also provide variances
                     h_data = hist.Hist.new.Regular(
                         channel_bins[channel["name"]], 0, channel_bins[channel["name"]]
@@ -129,7 +133,7 @@ def addSamples():  ##add sample names and expected counts to the Datacard
                         ],
                         axis=-1,
                     )
-                    DC.binParFlags.update({channel["name"]: True})
+                    data_card.binParFlags.update({channel["name"]: True})
                 else:  ##no staterror or shapesys->0 variance
                     h_data = hist.Hist.new.Regular(
                         channel_bins[channel["name"]], 0, channel_bins[channel["name"]]
@@ -148,32 +152,32 @@ def addSamples():  ##add sample names and expected counts to the Datacard
                 ] = h_data
 
 
-def addMods():  ##add systematics to DC
+def addMods():  ##add systematics to data_card
     for im, modifier in enumerate(systs):
         if "normsys" in modifier[1]:  ##normsys
-            DC.systs.append(
+            data_card.systs.append(
                 (modifier[0], False, "shape?", [], {})
             )  ##write normsys as 'shape?' so that Combine doesn't try to combine normsys and histosys mods of the same name
             for idxc, channel in enumerate(spec["channels"]):
-                DC.systs[im][4].update({channel["name"]: {}})
+                data_card.systs[im][4].update({channel["name"]: {}})
                 for idxs, sample in enumerate(channel["samples"]):
-                    for i in DC.systs:
+                    for i in data_card.systs:
                         i[4][channel["name"]].update({sample["name"]: 0.0})
         if "lumi" in modifier[1]:  ##lumi
-            DC.systs.append(
+            data_card.systs.append(
                 (modifier[0], False, "lnN", [], {})
             )  ##write lumi as lnN since they act the same way on the model
             for idxc, channel in enumerate(spec["channels"]):
-                DC.systs[im][4].update({channel["name"]: {}})
+                data_card.systs[im][4].update({channel["name"]: {}})
                 for idxs, sample in enumerate(channel["samples"]):
-                    for i in DC.systs:
+                    for i in data_card.systs:
                         i[4][channel["name"]].update({sample["name"]: 0.0})
         if "histosys" in modifier[1]:  ##histosys
-            DC.systs.append((modifier[0], False, "shape", [], {}))
+            data_card.systs.append((modifier[0], False, "shape", [], {}))
             for idxc, channel in enumerate(spec["channels"]):
-                DC.systs[im][4].update({channel["name"]: {}})
+                data_card.systs[im][4].update({channel["name"]: {}})
                 for idxs, sample in enumerate(channel["samples"]):
-                    for i in DC.systs:
+                    for i in data_card.systs:
                         i[4][channel["name"]].update({sample["name"]: 0.0})
 
     for idxc, channel in enumerate(spec["channels"]):
@@ -182,7 +186,7 @@ def addMods():  ##add systematics to DC
             names = []
             for mod in mods:
                 names.append(mod["name"])
-            for syst in DC.systs:
+            for syst in data_card.systs:
                 name = syst[0]
                 type = syst[2]
                 if name in names:  ##if systematic name is a modifier for this sample
@@ -308,8 +312,8 @@ def addSignal():  ##determine which samples are signal
             ):
                 for sig in signalMods:
                     if sig == mod["name"]:
-                        DC.isSignal.update({sample["name"]: True})
-                        DC.signals.append(sample["name"])
+                        data_card.isSignal.update({sample["name"]: True})
+                        data_card.signals.append(sample["name"])
 
 
 def addRateParams():  ##add normfactor mods as rateParams (excluding signal strength)
@@ -340,81 +344,87 @@ def addRateParams():  ##add normfactor mods as rateParams (excluding signal stre
                                 measurement["config"]["parameters"]
                             ):
                                 if mod["name"] == param["name"]:
-                                    DC.rateParams.update(
+                                    data_card.rateParams.update(
                                         {channel + "AND" + sample["name"]: []}
                                     )
-                                    DC.rateParams[
+                                    data_card.rateParams[
                                         channel + "AND" + sample["name"]
                                     ].append([[mod["name"], 1, 0, param["bounds"]], ""])
                                 else:
-                                    DC.rateParams.update(
+                                    data_card.rateParams.update(
                                         {channel + "AND" + sample["name"]: []}
                                     )
-                                    DC.rateParams[
+                                    data_card.rateParams[
                                         channel + "AND" + sample["name"]
                                     ].append([[mod["name"], 1, 0], ""])
 
 
-def writeDataCard(path):  ##manually write each line of the datacard from DC object
+def writeDataCard(
+    path,
+):  ##manually write each line of the datacard from data_card object
     with open(path, "w") as f:
-        f.write("imax " + str(size(DC.bins)) + "\n")
-        f.write("jmax " + str(size(DC.processes) - size(DC.isSignal.keys())) + "\n")
-        f.write("kmax " + str(size(DC.systs, 0)) + "\n")
-        if DC.hasShapes:
-            for channel in DC.shapeMap.keys():
-                for sample in DC.shapeMap[channel].keys():
+        f.write("imax " + str(size(data_card.bins)) + "\n")
+        f.write(
+            "jmax "
+            + str(size(data_card.processes) - size(data_card.isSignal.keys()))
+            + "\n"
+        )
+        f.write("kmax " + str(size(data_card.systs, 0)) + "\n")
+        if data_card.hasShapes:
+            for channel in data_card.shapeMap.keys():
+                for sample in data_card.shapeMap[channel].keys():
                     f.write(
                         "shapes "
                         + sample
                         + "  "
                         + channel
                         + "  "
-                        + DC.shapeMap[channel][sample][0]
+                        + data_card.shapeMap[channel][sample][0]
                         + "  "
-                        + DC.shapeMap[channel][sample][1]
+                        + data_card.shapeMap[channel][sample][1]
                     )
-                    if size(DC.shapeMap[channel][sample]) > 2:
-                        f.write("  " + DC.shapeMap[channel][sample][2] + "\n")
+                    if size(data_card.shapeMap[channel][sample]) > 2:
+                        f.write("  " + data_card.shapeMap[channel][sample][2] + "\n")
                     else:
                         f.write("\n")
 
         f.write("\n---------------------------------\n")
         f.write("bin ")
-        for bin in DC.obs.keys():
+        for bin in data_card.obs.keys():
             f.write(bin + " ")
         f.write("\n")
         f.write("observation ")
-        for channel in DC.obs.keys():
-            f.write(str(DC.obs[channel]) + " ")
+        for channel in data_card.obs.keys():
+            f.write(str(data_card.obs[channel]) + " ")
         f.write("\n---------------------------------\n")
         f.write("bin     ")
-        for channel in DC.obs.keys():
-            for sample in DC.exp[channel].keys():
+        for channel in data_card.obs.keys():
+            for sample in data_card.exp[channel].keys():
                 f.write(channel + "    ")
         f.write("\n")
         f.write("process     ")
-        for channel in DC.bins:
-            for sample in DC.exp[channel].keys():
+        for channel in data_card.bins:
+            for sample in data_card.exp[channel].keys():
                 f.write(sample + "    ")
         f.write("\n")
         f.write("process     ")
-        for channel in DC.bins:
-            for sample in DC.exp[channel].keys():
-                if sample in DC.signals:
-                    f.write(str(-1 * DC.processes.index(sample)) + "     ")
+        for channel in data_card.bins:
+            for sample in data_card.exp[channel].keys():
+                if sample in data_card.signals:
+                    f.write(str(-1 * data_card.processes.index(sample)) + "     ")
                 else:
-                    f.write(str(DC.processes.index(sample) + 1) + "     ")
+                    f.write(str(data_card.processes.index(sample) + 1) + "     ")
         f.write("\n")
         f.write("rate     ")
-        for channel in DC.bins:
-            for sample in DC.exp[channel].keys():
+        for channel in data_card.bins:
+            for sample in data_card.exp[channel].keys():
 
-                f.write(str(DC.exp[channel][sample]) + "     ")
+                f.write(str(data_card.exp[channel][sample]) + "     ")
         f.write("\n---------------------------------\n")
-        for syst in DC.systs:
+        for syst in data_card.systs:
             f.write(syst[0] + "  " + syst[2] + "  ")
             for bin in syst[4].keys():
-                for sample in DC.exp[bin].keys():
+                for sample in data_card.exp[bin].keys():
                     if syst[4][bin][sample] != 0:
                         f.write(str(syst[4][bin][sample]) + "  ")
                     else:
@@ -422,38 +432,38 @@ def writeDataCard(path):  ##manually write each line of the datacard from DC obj
 
             f.write("\n")
         f.write("\n---------------------------------\n")
-        for cAp in DC.rateParams.keys():
+        for cAp in data_card.rateParams.keys():
             dir = cAp.split("AND")
-            for i in range(size(DC.rateParams[cAp], 0)):
-                if size(DC.rateParams[cAp][i][0]) > 3:
+            for i in range(size(data_card.rateParams[cAp], 0)):
+                if size(data_card.rateParams[cAp][i][0]) > 3:
                     f.write(
-                        str(DC.rateParams[cAp][i][0][0])
+                        str(data_card.rateParams[cAp][i][0][0])
                         + " "
                         + "rateParam "
                         + dir[0]
                         + " "
                         + dir[1]
                         + " "
-                        + str(DC.rateParams[cAp][i][0][1])
+                        + str(data_card.rateParams[cAp][i][0][1])
                         + " "
-                        + DC.rateParams[cAp][i][0][3]
+                        + data_card.rateParams[cAp][i][0][3]
                     )
                 else:
                     f.write(
-                        str(DC.rateParams[cAp][i][0][0])
+                        str(data_card.rateParams[cAp][i][0][0])
                         + " "
                         + "rateParam "
                         + dir[0]
                         + " "
                         + dir[1]
                         + " "
-                        + str(DC.rateParams[cAp][i][0][1])
+                        + str(data_card.rateParams[cAp][i][0][1])
                     )
                 f.write("\n")
         f.write("\n---------------------------------\n")
         for idxc, channel in enumerate(channels):
-            if channel in DC.binParFlags.keys():
-                if DC.binParFlags[channel] == True:  ##double check to be safe
+            if channel in data_card.binParFlags.keys():
+                if data_card.binParFlags[channel] == True:  ##double check to be safe
                     shapesys = False
                     staterror = False
                     for idxs, sample in enumerate(spec["channels"][idxc]["samples"]):
@@ -527,7 +537,7 @@ def main():
                 if "staterror" not in mod:
                     systs.append(mod)
 
-    DC = Datacard()
+    data_card = Datacard()
 
     file = uproot.recreate(options.shapefile)
     addChannels()

--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -490,12 +490,11 @@ def main():
     lumi = model.config.parameters
 
     # generate list of mods without normfactors, shapesys, staterror
-    systs = []
-    for mod in modifiers:
-        if "normfactor" not in mod:
-            if "shapesys" not in mod:
-                if "staterror" not in mod:
-                    systs.append(mod)
+    systs = [
+        mod
+        for mod in modifiers
+        if "normfactor" not in mod and "shapesys" not in mod and "staterror" not in mod
+    ]
 
     data_card = Datacard()
 

--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -14,15 +14,6 @@ try:
 except:
     print("Either the docker container has not been created properly or Combine commands have not been mounted. Please fix this and try again")
 
-parser = OptionParser()  ##add command line args
-parser.add_option(
-    "-O", "--out-datacard", dest="outdatacard", default="converted_datacard.txt", help = "desired name of datacard file"
-)
-parser.add_option("-s", "--shape-file", dest="shapefile", default="shapes.root", help = "desired name of shapes file")
-options, args = parser.parse_args()
-
-
-
 
 def addChannels():  ##add each channel to Datacard object, add observed counts
     DC.bins = [channel["name"] for i, channel in enumerate(spec["channels"])]
@@ -495,7 +486,14 @@ def writeDataCard(path):  ##manually write each line of the datacard from DC obj
                         )
         f.close()
 
-if __name__ == "__main__":
+def main():
+    parser = OptionParser()  # add command line args
+    parser.add_option(
+        "-O", "--out-datacard", dest="outdatacard", default="converted_datacard.txt", help = "desired name of datacard file"
+    )
+    parser.add_option("-s", "--shape-file", dest="shapefile", default="shapes.root", help = "desired name of shapes file")
+    options, args = parser.parse_args()
+
     with open(args[0]) as serialized:
         spec = json.load(serialized)
     workspace = pyhf.Workspace(spec)
@@ -508,7 +506,7 @@ if __name__ == "__main__":
     modifiers = model.config.modifiers
     lumi = model.config.parameters
 
-    ##generate list of mods without normfactors, shapesys, staterror
+    # generate list of mods without normfactors, shapesys, staterror
     systs = []
     for mod in modifiers:
         if "normfactor" not in mod:
@@ -517,7 +515,7 @@ if __name__ == "__main__":
                     systs.append(mod)
 
 
-    DC = Datacard() 
+    DC = Datacard()
 
 
     file = uproot.recreate(options.shapefile)
@@ -528,3 +526,6 @@ if __name__ == "__main__":
     addRateParams()
     file.close()
     writeDataCard(options.outdatacard)
+
+if __name__ == "__main__":
+    main()

--- a/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
@@ -179,20 +179,21 @@ def addMeasurements(spec: dict, data_card, channels, samples, sig):
                         )
 
 
-def addNormFactor(spec: dict, data_card):
+def addNormFactor(spec: dict, data_card, channels, samples, sig):
     """
     Add all normfactor modifiers to spec
     """
     for idxc, channel in enumerate(channels):
         for idxs, sample in enumerate(samples):
-            if (channel + "AND" + sample) in data_card.rateParams.keys():
-                name = data_card.rateParams[channel + "AND" + sample][0][0][0]
+            if f"{channel}AND{sample}" in data_card.rateParams.keys():
+                name = data_card.rateParams[f"{channel}AND{sample}"][0][0][0]
                 spec["channels"][idxc]["samples"][idxs]["modifiers"].append(
                     {"name": name, "type": "normfactor", "data": None}
                 )
-            elif sig[sample] == True:  ##add signal strength modifier
+
+            elif sig[sample] == True:
                 spec["channels"][idxc]["samples"][idxs]["modifiers"].append(
-                    {"name": "mu_" + sample, "type": "normfactor", "data": None}
+                    {"name": f"mu_{sample}", "type": "normfactor", "data": None}
                 )
 
 
@@ -338,7 +339,7 @@ def main():
     addChannels(spec, data_card, channels, observations)
     addSamples(spec, data_card, channels, samples, exp_values)
     addMeasurements(spec, data_card, channels, samples, sig)
-    addNormFactor(spec, data_card)
+    addNormFactor(spec, data_card, channels, samples, sig)
     addMods(spec, data_card)
 
     with open(options.outfile, "w") as file:

--- a/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
@@ -109,7 +109,10 @@ def getUncertDown(
     return hist
 
 
-def addChannels(spec: dict):  ##add each channel and associated observation to the spec
+def addChannels(spec: dict, data_card):
+    """
+    Add each channel and associated observation to the spec
+    """
     if data_card.hasShapes:
         for idxc, channel in enumerate(channels):
             spec["channels"].append({"name": channel, "samples": []})
@@ -122,7 +125,10 @@ def addChannels(spec: dict):  ##add each channel and associated observation to t
             spec["observations"].append({"name": channel, "data": [observations[idxc]]})
 
 
-def addSamples(spec: dict):  ##add sample names and expected values to spec
+def addSamples(spec: dict, data_card):
+    """
+    Add sample names and expected values to spec
+    """
     if data_card.hasShapes:
         for idxc, channel in enumerate(channels):
             for idxs, sample in enumerate(samples):
@@ -149,7 +155,10 @@ def addSamples(spec: dict):  ##add sample names and expected values to spec
                     )
 
 
-def addMeasurements(spec: dict):  ##add signal measurements to spec
+def addMeasurements(spec: dict, data_card):
+    """
+    Add signal measurements to spec
+    """
     for idxc, channel in enumerate(channels):
         for idxs, sample in enumerate(samples):
             if sig[sample] == True:
@@ -173,7 +182,10 @@ def addMeasurements(spec: dict):  ##add signal measurements to spec
                         )
 
 
-def addNormFactor(spec: dict):  ##add all normfactor modifiers to spec
+def addNormFactor(spec: dict, data_card):
+    """
+    Add all normfactor modifiers to spec
+    """
     for idxc, channel in enumerate(channels):
         for idxs, sample in enumerate(samples):
             if (channel + "AND" + sample) in data_card.rateParams.keys():
@@ -187,7 +199,10 @@ def addNormFactor(spec: dict):  ##add all normfactor modifiers to spec
                 )
 
 
-def addMods(spec: dict):  ##add systematics as modifiers
+def addMods(spec: dict, data_card):
+    """
+    Add systematics as modifiers
+    """
     for syst in mods:
         name = syst[0]
         mod_type = syst[2]
@@ -297,12 +312,12 @@ def addMods(spec: dict):  ##add systematics as modifiers
                         )
 
 
-def toJSON(spec: dict):
-    addChannels(spec)
-    addSamples(spec)
-    addMeasurements(spec)
-    addNormFactor(spec)
-    addMods(spec)
+def toJSON(spec: dict, data_card):
+    addChannels(spec, data_card)
+    addSamples(spec, data_card)
+    addMeasurements(spec, data_card)
+    addNormFactor(spec, data_card)
+    addMods(spec, data_card)
 
 
 def main():
@@ -329,7 +344,7 @@ def main():
     sig = data_card.isSignal
     mods = data_card.systs
     spec = {"channels": [], "observations": [], "measurements": [], "version": "1.0.0"}
-    toJSON(spec)
+    toJSON(spec, data_card)
 
     with open(options.outfile, "w") as file:
         file.write(json.dumps(spec, indent=2))

--- a/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
@@ -312,14 +312,6 @@ def addMods(spec: dict, data_card):
                         )
 
 
-def toJSON(spec: dict, data_card):
-    addChannels(spec, data_card)
-    addSamples(spec, data_card)
-    addMeasurements(spec, data_card)
-    addNormFactor(spec, data_card)
-    addMods(spec, data_card)
-
-
 def main():
     parser = OptionParser()
     DP.addDatacardParserOptions(parser)
@@ -344,7 +336,13 @@ def main():
     sig = data_card.isSignal
     mods = data_card.systs
     spec = {"channels": [], "observations": [], "measurements": [], "version": "1.0.0"}
-    toJSON(spec, data_card)
+
+    # convert to JSON spec
+    addChannels(spec, data_card)
+    addSamples(spec, data_card)
+    addMeasurements(spec, data_card)
+    addNormFactor(spec, data_card)
+    addMods(spec, data_card)
 
     with open(options.outfile, "w") as file:
         file.write(json.dumps(spec, indent=2))

--- a/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
@@ -125,26 +125,22 @@ def addChannels(spec: dict, data_card, channels, observations):
             spec["observations"].append({"name": channel, "data": [observations[idxc]]})
 
 
-def addSamples(spec: dict, data_card):
+def addSamples(spec: dict, data_card, channels, samples, exp_values):
     """
     Add sample names and expected values to spec
     """
     if data_card.hasShapes:
         for idxc, channel in enumerate(channels):
-            for idxs, sample in enumerate(samples):
+            for sample in samples:
                 hist = getHist(data_card.shapeMap, channel, sample)
                 data = hist.values().tolist()
                 if sample in exp_values[channel].keys():
                     spec["channels"][idxc]["samples"].append(
-                        {
-                            "name": sample,
-                            "data": data,
-                            "modifiers": [],
-                        }
+                        {"name": sample, "data": data, "modifiers": []}
                     )
     else:
         for idxc, channel in enumerate(channels):
-            for idxs, sample in enumerate(samples):
+            for sample in samples:
                 if sample in exp_values[channel].keys():
                     spec["channels"][idxc]["samples"].append(
                         {
@@ -339,7 +335,7 @@ def main():
 
     # convert to JSON spec
     addChannels(spec, data_card, channels, observations)
-    addSamples(spec, data_card)
+    addSamples(spec, data_card, channels, samples, exp_values)
     addMeasurements(spec, data_card)
     addNormFactor(spec, data_card)
     addMods(spec, data_card)

--- a/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
@@ -3,23 +3,14 @@ from numpy.core.fromnumeric import size
 import uproot
 import json
 from optparse import OptionParser
+
 try:
     import HiggsAnalysis.CombinedLimit.DatacardParser as DP
     from HiggsAnalysis.CombinedLimit.Datacard import Datacard
 except:
-    print("Either the docker container has not been created properly or Combine commands have not been mounted. Please fix this and try again")
-
-
-
-parser = OptionParser()
-DP.addDatacardParserOptions(parser)
-parser.add_option(
-    "-O", "--out-file", dest="outfile", default="converted_workspace.json", help = "desired name of JSON file"
-)
-options, args = parser.parse_args()  ##add command line args
-
-
-
+    print(
+        "Either the docker container has not been created properly or Combine commands have not been mounted. Please fix this and try again."
+    )
 
 
 def getShapeFile(
@@ -308,16 +299,22 @@ def toJSON(spec: dict):
     addMods(spec)
 
 
-def writeFileName(name):
-    with open(name, "w") as file:
-        file.write(json.dumps(spec, indent=2))
+def main():
+    parser = OptionParser()
+    DP.addDatacardParserOptions(parser)
+    parser.add_option(
+        "-O",
+        "--out-file",
+        dest="outfile",
+        default="converted_workspace.json",
+        help="desired name of JSON file",
+    )
+    options, args = parser.parse_args()  # add command line args
 
-if __name__ == "__main__":
-    DC = Datacard()  ##create Datacard object
+    DC = Datacard()  # create Datacard object
     with open(args[0]) as dc_file:
         DC = Datacard()
         DC = DP.parseCard(file=dc_file, options=options)
-   
 
     channels = [channel for channel in DC.bins]
     observations = [obs for channel, obs in DC.obs.items()]
@@ -327,6 +324,10 @@ if __name__ == "__main__":
     mods = DC.systs
     spec = {"channels": [], "observations": [], "measurements": [], "version": "1.0.0"}
     toJSON(spec)
-    writeFileName(options.outfile)
+
+    with open(options.outfile, "w") as file:
+        file.write(json.dumps(spec, indent=2))
 
 
+if __name__ == "__main__":
+    main()

--- a/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
@@ -13,18 +13,18 @@ except:
     )
 
 
-def getShapeFile(
-    shapeMap: dict, channel, sample
-) -> string:  ##get shape file of specific sample
+def getShapeFile(shapeMap: dict, channel, sample) -> string:
+    """
+    Get shape file of specific sample
+    """
     file = ""
-    if not channel in shapeMap.keys():
-        if "*" in shapeMap.keys():
-            if not sample in shapeMap["*"]:
-                if "*" in shapeMap["*"].keys():
-                    file = shapeMap["*"]["*"][0]
-            else:
+    if channel not in shapeMap:
+        if "*" in shapeMap:
+            if sample in shapeMap["*"]:
                 file = shapeMap["*"][sample][0]
-    elif not sample in shapeMap[channel]:
+            elif "*" in shapeMap["*"].keys():
+                file = shapeMap["*"]["*"][0]
+    elif sample not in shapeMap[channel]:
         if "*" in shapeMap[channel].keys():
             file = shapeMap[channel]["*"][0]
     else:

--- a/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
@@ -151,21 +151,22 @@ def addSamples(spec: dict, data_card, channels, samples, exp_values):
                     )
 
 
-def addMeasurements(spec: dict, data_card):
+def addMeasurements(spec: dict, data_card, channels, samples, sig):
     """
     Add signal measurements to spec
     """
-    for idxc, channel in enumerate(channels):
-        for idxs, sample in enumerate(samples):
+    for channel in channels:
+        for sample in samples:
             if sig[sample] == True:
                 spec["measurements"].append(
                     {
-                        "name": "Measurement_" + sample,
-                        "config": {"poi": "mu_" + sample, "parameters": []},
+                        "name": f"Measurement_{sample}",
+                        "config": {"poi": f"mu_{sample}", "parameters": []},
                     }
                 )
-                if channel + "AND" + sample in data_card.rateParams.keys():
-                    for param in data_card.rateParams[channel + "AND" + sample]:
+
+                if f"{channel}AND{sample}" in data_card.rateParams.keys():
+                    for param in data_card.rateParams[f"{channel}AND{sample}"]:
                         spec["measurements"][len(spec["measurements"] - 1)]["config"][
                             "parameters"
                         ].append(
@@ -336,7 +337,7 @@ def main():
     # convert to JSON spec
     addChannels(spec, data_card, channels, observations)
     addSamples(spec, data_card, channels, samples, exp_values)
-    addMeasurements(spec, data_card)
+    addMeasurements(spec, data_card, channels, samples, sig)
     addNormFactor(spec, data_card)
     addMods(spec, data_card)
 

--- a/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
@@ -109,12 +109,12 @@ def getUncertDown(
     return hist
 
 
-def addChannels(spec: dict, data_card):
+def addChannels(spec: dict, data_card, channels, observations):
     """
     Add each channel and associated observation to the spec
     """
     if data_card.hasShapes:
-        for idxc, channel in enumerate(channels):
+        for channel in channels:
             spec["channels"].append({"name": channel, "samples": []})
             hist = getHist(data_card.shapeMap, channel, "data_obs")
             data = hist.values().tolist()
@@ -338,7 +338,7 @@ def main():
     spec = {"channels": [], "observations": [], "measurements": [], "version": "1.0.0"}
 
     # convert to JSON spec
-    addChannels(spec, data_card)
+    addChannels(spec, data_card, channels, observations)
     addSamples(spec, data_card)
     addMeasurements(spec, data_card)
     addNormFactor(spec, data_card)


### PR DESCRIPTION
Resolves #18 

* [x] Add aliases to packaging in `pyproject.toml`.
* [x] Update the [src/pyhf_combine_converter/pyhf_convert_to_datacard.py](https://github.com/peterridolfi/Pyhf-to-Combine-converter/blob/92557b27550d3373658da21ad7f40418568d2b4b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py) and [`src/pyhf_combine_converter/pyhf_converted_from_datacard.py`](https://github.com/peterridolfi/Pyhf-to-Combine-converter/blob/92557b27550d3373658da21ad7f40418568d2b4b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py) files to have main functions that work. c.f. `hist`'s [`src/hist/classichist.py`](https://github.com/scikit-hep/hist/blob/c68a6e6fe90eddc21b82ae758f2f6f992ae35f4b/src/hist/classichist.py) for an example.
* [x] Update the instructions in the README

https://github.com/peterridolfi/Pyhf-to-Combine-converter/blob/92557b27550d3373658da21ad7f40418568d2b4b/README.md?plain=1#L24-L35

to reflect the new command line.

```
* Add CLI API of `pyhf-to-combine` and `combine-to-pyhf`.
* Revise package API to not operate in the global scope but to require necessary data
  structures to be passed in as function arguments.
* Refactor to use list comprehensions when possible, remove unneeded calls to enumerate,
  use f-strings where possible for increased speed and readability
* Add CLI API names to README.
```