### PR TITLE
build: Make version PEP 440 compliant

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,6 @@ combine-to-pyhf = "pyhf_combine_converter.pyhf_converted_from_datacard:main"
 [tool.hatch]
 version.source = "vcs"
 build.hooks.vcs.version-file = "src/pyhf_combine_converter/version.py"
+
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"


### PR DESCRIPTION
* Set `setuptools-scm` `'local_scheme'` option to

```
local_scheme = "no-local-version"
```

to truncate commit hash from version to make uploads to TestPyPI viable.
   - c.f. https://github.com/pypa/setuptools_scm/blob/e1283177b23ccf254739aa8292448154c54741c8/README.rst#version-number-construction

This is set through `hatch-vcs` through the version source option "raw-options"
   - c.f. https://github.com/ofek/hatch-vcs/blob/17011d84bb574cc41761bdf460a6f3e443cb97e8/README.md#version-source-options
   - c.f. https://github.com/ofek/hatch-vcs/discussions/12