### PR TITLE
fix: Separate Python API from CLI API

### DIFF
--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -51,7 +51,7 @@ def addChannels(file, spec, data_card, channel_bins):
             file[channel["name"] + "/data_obs"] = h_data
 
 
-def addSamples(file, spec, data_card, channel_bins, samples, options):
+def addSamples(file, spec, data_card, channel_bins, samples, shapefile):
     """
     Add sample names and expected counts to the Datacard
     """
@@ -67,7 +67,7 @@ def addSamples(file, spec, data_card, channel_bins, samples, options):
             # shapes
             data_card.shapeMap.update({channel["name"]: {}})
             data_card.shapeMap[channel["name"]].update(
-                {"data_obs": [options.shapefile, channel["name"] + "/" + "data_obs"]}
+                {"data_obs": [shapefile, channel["name"] + "/" + "data_obs"]}
             )
             for idxs, sample in enumerate(channel["samples"]):
                 data = sum(sample["data"])
@@ -84,7 +84,7 @@ def addSamples(file, spec, data_card, channel_bins, samples, options):
                     data_card.shapeMap[channel["name"]].update(
                         {
                             spec["channels"][idxc]["samples"][idxs]["name"]: [
-                                options.shapefile,
+                                shapefile,
                                 channel["name"]
                                 + "/"
                                 + spec["channels"][idxc]["samples"][idxs]["name"],
@@ -99,7 +99,7 @@ def addSamples(file, spec, data_card, channel_bins, samples, options):
                     data_card.shapeMap[channel["name"]].update(
                         {
                             spec["channels"][idxc]["samples"][idxs]["name"]: [
-                                options.shapefile,
+                                shapefile,
                                 channel["name"]
                                 + "/"
                                 + spec["channels"][idxc]["samples"][idxs]["name"],
@@ -460,25 +460,8 @@ def write_data_card(spec, data_card, channels, path):
                     f.write(f"{channel} autoMCStats 0 0 2" + "\n")
 
 
-def main():
-    parser = OptionParser()  # add command line args
-    parser.add_option(
-        "-O",
-        "--out-datacard",
-        dest="outdatacard",
-        default="converted_datacard.txt",
-        help="desired name of datacard file",
-    )
-    parser.add_option(
-        "-s",
-        "--shape-file",
-        dest="shapefile",
-        default="shapes.root",
-        help="desired name of shapes file",
-    )
-    options, args = parser.parse_args()
-
-    with open(args[0]) as serialized:
+def pyhf_convert_to_datacard(workspace, outdatacard, shapefile):
+    with open(workspace) as serialized:
         spec = json.load(serialized)
     workspace = pyhf.Workspace(spec)
     model = workspace.model()
@@ -498,14 +481,38 @@ def main():
 
     data_card = Datacard()
 
-    file = uproot.recreate(options.shapefile)
+    file = uproot.recreate(shapefile)
     addChannels(file, spec, data_card, channel_bins)
-    addSamples(file, spec, data_card, channel_bins, samples, options)
+    addSamples(file, spec, data_card, channel_bins, samples, shapefile)
     addMods(file, spec, data_card, channel_bins, systs)
     addSignal(spec, data_card, channels, modifiers)
     addRateParams(spec, data_card, channels, modifiers)
     file.close()
-    write_data_card(spec, data_card, channels, options.outdatacard)
+    write_data_card(spec, data_card, channels, outdatacard)
+
+
+def main():
+    # Add command line args
+    parser = OptionParser()
+    parser.add_option(
+        "-O",
+        "--out-datacard",
+        dest="outdatacard",
+        default="converted_datacard.txt",
+        help="desired name of datacard file",
+    )
+    parser.add_option(
+        "-s",
+        "--shape-file",
+        dest="shapefile",
+        default="shapes.root",
+        help="desired name of shapes file",
+    )
+    options, args = parser.parse_args()
+
+    pyhf_convert_to_datacard(
+        workspace=args[0], outdatacard=options.outdatacard, shapefile=options.shapefile
+    )
 
 
 if __name__ == "__main__":

--- a/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
@@ -305,20 +305,9 @@ def addMods(spec: dict, data_card, channels, samples, exp_values, mods):
                         )
 
 
-def main():
-    parser = OptionParser()
-    DP.addDatacardParserOptions(parser)
-    parser.add_option(
-        "-O",
-        "--out-file",
-        dest="outfile",
-        default="converted_workspace.json",
-        help="desired name of JSON file",
-    )
-    options, args = parser.parse_args()  # add command line args
-
+def pyhf_converted_from_datacard(input_datacard, outfile, options=None):
     data_card = Datacard()  # create Datacard object
-    with open(args[0]) as dc_file:
+    with open(input_datacard) as dc_file:
         data_card = Datacard()
         data_card = DP.parseCard(file=dc_file, options=options)
 
@@ -337,8 +326,26 @@ def main():
     addNormFactor(spec, data_card, channels, samples, sig)
     addMods(spec, data_card, channels, samples, exp_values, mods)
 
-    with open(options.outfile, "w") as file:
+    with open(outfile, "w") as file:
         file.write(json.dumps(spec, indent=2))
+
+
+def main():
+    # Add command line args
+    parser = OptionParser()
+    DP.addDatacardParserOptions(parser)
+    parser.add_option(
+        "-O",
+        "--out-file",
+        dest="outfile",
+        default="converted_workspace.json",
+        help="desired name of JSON file",
+    )
+    options, args = parser.parse_args()
+
+    pyhf_converted_from_datacard(
+        input_datacard=args[0], outfile=options.outfile, options=options
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #24 

* Separate the CLI API from the Python API by setting the signature of
  the Python API and then feeding in the args and then necessary options
  from argparse.