### PR TITLE
refactor: Use list over list comprehension for iterables

### DIFF
--- a/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
@@ -311,9 +311,9 @@ def pyhf_converted_from_datacard(input_datacard, outfile, options=None):
         data_card = Datacard()
         data_card = DP.parseCard(file=dc_file, options=options)
 
-    channels = [channel for channel in data_card.bins]
+    channels = list(data_card.bins)
+    samples = list(data_card.processes)
     observations = [obs for channel, obs in data_card.obs.items()]
-    samples = [sample for sample in data_card.processes]
     exp_values = data_card.exp
     sig = data_card.isSignal
     mods = data_card.systs


### PR DESCRIPTION
* For iterables can just call `list` on them instead of unpacking with a list comprehension.