### PR TITLE
feat: Use module level `__dir__` to restrict public API views

### DIFF
--- a/src/pyhf_combine_converter/__init__.py
+++ b/src/pyhf_combine_converter/__init__.py
@@ -1,2 +1,11 @@
 # Convenient access to the version number
 from pyhf_combine_converter.version import version as __version__
+
+from pyhf_combine_converter import pyhf_convert_to_datacard
+from pyhf_combine_converter import pyhf_converted_from_datacard
+
+__all__ = ["pyhf_convert_to_datacard", "pyhf_converted_from_datacard", "__version__"]
+
+
+def __dir__():
+    return __all__

--- a/src/pyhf_combine_converter/__init__.py
+++ b/src/pyhf_combine_converter/__init__.py
@@ -4,7 +4,7 @@ from pyhf_combine_converter.version import version as __version__
 from pyhf_combine_converter import pyhf_convert_to_datacard
 from pyhf_combine_converter import pyhf_converted_from_datacard
 
-__all__ = ["pyhf_convert_to_datacard", "pyhf_converted_from_datacard", "__version__"]
+__all__ = ["__version__", "pyhf_convert_to_datacard", "pyhf_converted_from_datacard"]
 
 
 def __dir__():

--- a/src/pyhf_combine_converter/__init__.py
+++ b/src/pyhf_combine_converter/__init__.py
@@ -2,9 +2,7 @@
 from pyhf_combine_converter.version import version as __version__
 
 from pyhf_combine_converter.pyhf_convert_to_datacard import pyhf_convert_to_datacard
-from pyhf_combine_converter.pyhf_converted_from_datacard import (
-    pyhf_converted_from_datacard,
-)
+from pyhf_combine_converter.pyhf_converted_from_datacard import pyhf_converted_from_datacard
 
 __all__ = ["__version__", "pyhf_convert_to_datacard", "pyhf_converted_from_datacard"]
 

--- a/src/pyhf_combine_converter/__init__.py
+++ b/src/pyhf_combine_converter/__init__.py
@@ -1,8 +1,10 @@
 # Convenient access to the version number
 from pyhf_combine_converter.version import version as __version__
 
-from pyhf_combine_converter import pyhf_convert_to_datacard
-from pyhf_combine_converter import pyhf_converted_from_datacard
+from pyhf_combine_converter.pyhf_convert_to_datacard import pyhf_convert_to_datacard
+from pyhf_combine_converter.pyhf_converted_from_datacard import (
+    pyhf_converted_from_datacard,
+)
 
 __all__ = ["__version__", "pyhf_convert_to_datacard", "pyhf_converted_from_datacard"]
 

--- a/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_convert_to_datacard.py
@@ -17,6 +17,12 @@ except:
         "Either the docker container has not been created properly or Combine commands have not been mounted. Please fix this and try again."
     )
 
+__all__ = ["pyhf_convert_to_datacard"]
+
+
+def __dir__():
+    return __all__
+
 
 def addChannels(file, spec, data_card, channel_bins):
     """

--- a/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
+++ b/src/pyhf_combine_converter/pyhf_converted_from_datacard.py
@@ -13,6 +13,13 @@ except:
     )
 
 
+__all__ = ["pyhf_converted_from_datacard"]
+
+
+def __dir__():
+    return __all__
+
+
 def getShapeFile(shapeMap: dict, channel, sample) -> string:
     """
     Get shape file of specific sample


### PR DESCRIPTION
As the package is Python 3.7+ we can use `__all__` and `__dir__` to restrict the API view.

Allow for

```
>>> import pyhf_combine_converter
>>> dir(pyhf_combine_converter)
['__version__', 'pyhf_convert_to_datacard', 'pyhf_converted_from_datacard']
>>> help(pyhf_combine_converter.pyhf_convert_to_datacard)
Help on function pyhf_convert_to_datacard in module pyhf_combine_converter.pyhf_convert_to_datacard:

pyhf_convert_to_datacard(workspace, outdatacard, shapefile)
```

```
* Use module level __dir__ in combination with __all__ to restrict the public API import views to useful imports.
* c.f. https://snarky.ca/lazy-importing-in-python-3-7/
```