### PR TITLE
build: Set lower bounds on build backend requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = [
+  "hatchling>=1.11.1",
+  "hatch-vcs>=0.2.0",
+]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
* Use the versions of hatchline and hatch-vcs available at the release of v0.0.5.